### PR TITLE
refs #34060

### DIFF
--- a/war/src/main/webapp/themes/default/css/aui.css
+++ b/war/src/main/webapp/themes/default/css/aui.css
@@ -1272,6 +1272,25 @@ button span,
   button {
     padding: 0 6px !important;
   }
+   input[type=submit],
+  input[type=button],
+  input[type=reset],
+  button,
+  .auiButton,
+  .auiButtonAction,
+  .auiButtonBold,
+  .auiButtonSearch,
+  .auiButtonSmall,
+  .auiButtonDisabled,
+  .auiButtonIcon,
+  .auiButtonDummy,
+  .auiButtonIconDummy,
+  .auiSelectButton a,
+  .auiSelectButtonSmall a,
+  .auiWidget .auiSelectButton a,
+  .auiWidget .auiSelectButtonSmall a {
+    line-height: -moz-block-height;
+  }
 }
 
 *:first-child + html input[type=submit],


### PR DESCRIPTION
メッセージ > Firefoxでボタンの文字が下付きになっている