### PR TITLE
refs #35219

### DIFF
--- a/war/src/main/webapp/themes/default/css/aui.css
+++ b/war/src/main/webapp/themes/default/css/aui.css
@@ -3077,6 +3077,9 @@ button[disabled]:active {
 .auiSearch {
   position: relative;
 }
+.auiSearch input[type="text"] {
+  outline: none;
+}
 .auiSearch input.long {
   min-width: 320px;
 }


### PR DESCRIPTION
全般 > Chromeで検索のテキストフォームに青い枠線が表示される