### PR TITLE
refs #35034

### DIFF
--- a/war/src/main/webapp/themes/default/css/mobile.css
+++ b/war/src/main/webapp/themes/default/css/mobile.css
@@ -2239,7 +2239,7 @@ body.messageRoomList .auiPortletBody {
   background-color: transparent !important;
 }
 body.messageRoomList .dijitContentPane {
-	overflow:hidden;
+	/*overflow:hidden;*/
 }
 body.messageRoomList .messageSummary .date,
 body.messageRoomList .messageSummary .name,


### PR DESCRIPTION
モバイル > 画像プレビューの✕ボタンがメッセージ検索画面で表示されない