### PR TITLE
refs #35388

### DIFF
--- a/war/src/main/webapp/themes/default/css/aui.css
+++ b/war/src/main/webapp/themes/default/css/aui.css
@@ -2347,6 +2347,7 @@ button[disabled]:active {
 }
 .imgPopup .meta a {
   display: inline-block;
+  text-decoration: none;
 }
 .imgPopup .meta [class*="icon-"] {
   font-size: 24px;


### PR DESCRIPTION
全般 > IEで拡大画像表示の際のバツボタンに下線が付く