### PR TITLE
Bugfix/schedule weekly margin

### DIFF
--- a/portlets/schedule/src/main/webapp/WEB-INF/templates/vm/portlets/html/schedule-weekly-group.vm
+++ b/portlets/schedule/src/main/webapp/WEB-INF/templates/vm/portlets/html/schedule-weekly-group.vm
@@ -445,6 +445,7 @@ $!{record.ToDoResultData.TodoName}
 #end
 #end
 #end
+<div class="calendarFooter"></div>
 #end
 #if($!{record.Date.Value.equals($result.Today.Value)})
 ##</td></tr></tbody></table>

--- a/portlets/schedule/src/main/webapp/WEB-INF/templates/vm/portlets/html/schedule-weekly.vm
+++ b/portlets/schedule/src/main/webapp/WEB-INF/templates/vm/portlets/html/schedule-weekly.vm
@@ -175,8 +175,6 @@ $!{record.Date.Day} $!{record.Date.DayOfWeek}
 #end
 #end
 <div class="calendarFooter"></div>
-
-
 </td>
 #end
 </tr>


### PR DESCRIPTION
スケジュール > 週の設備の方に余白のタグがない