### PR TITLE
refs #36725

### DIFF
--- a/war/src/main/webapp/themes/default/css/aui.css
+++ b/war/src/main/webapp/themes/default/css/aui.css
@@ -4072,7 +4072,7 @@ ul.attachments {
 #timelineOuter .auiSummaryMeta{
   margin: 0;
 }
-.message .avatar a {
+.avatar a {
   text-decoration:none !important;
 }
 


### PR DESCRIPTION
Aipo.com > Chrome でブログのアイコン画像の右側に下線が入ってしまっている。