### PR TITLE
refs #37152

### DIFF
--- a/portlets/timeline/src/main/webapp/WEB-INF/templates/vm/portlets/html/ajax-timeline-url.vm
+++ b/portlets/timeline/src/main/webapp/WEB-INF/templates/vm/portlets/html/ajax-timeline-url.vm
@@ -19,9 +19,7 @@
 ## ---------------------------------------------------------------------------
 <div class="tlInputAttachment">
 <div class="floatRight">
-  <a href="javascript:aipo.timeline.deleteClip('$portlet.ID')" title="$l10n.TIMELINE_DELETION">
-    <span class="auiWFicon"><i class="icon-remove"></i></span>
-  </a>
+  <a href="javascript:aipo.timeline.deleteClip('$portlet.ID')" title="$l10n.TIMELINE_DELETION"><span class="auiWFicon"><i class="icon-remove"></i></span></a>
 </div>
 <div class="tlClipBoard clearfix" id="tlClipBoard_$!{portlet.ID}">
   <input type="hidden" id="TimelinePage_$!{portlet.ID}" name="TimelinePage_$!{portlet.ID}" value="1"/>


### PR DESCRIPTION
 Chrome でタイムラインURL添付時のバツボタンの右側に下線が入ってしまっている件の対応