### PR TITLE
refs #37857

### DIFF
--- a/portlets/exttimecard/src/main/java/com/aimluck/eip/exttimecard/ExtTimecardSummaryListSelectData.java
+++ b/portlets/exttimecard/src/main/java/com/aimluck/eip/exttimecard/ExtTimecardSummaryListSelectData.java
@@ -619,7 +619,7 @@ public class ExtTimecardSummaryListSelectData extends
       boolean isCurrentMonth =
         Integer.parseInt(viewMonth.getMonth()) == cal.get(Calendar.MONTH) + 1;
       if ((startDay == 1 && !isCurrentMonth)
-        || (startDay > 1 && cal.get(Calendar.DATE) < startDay)) {
+        || (startDay > 1 && cal.get(Calendar.DATE) < startDay && isCurrentMonth)) {
         rd.setCurrentMonth(false);
       } else {
         rd.setCurrentMonth(true);


### PR DESCRIPTION
タイムカード集計画面において勤務形態の開始日が1日以外になっていた場合にその月以外（例えば、開始日5/10だった場合に、6/1 ~
6/10）の勤怠情報が反映されていなかった問題を解決。