### PR TITLE
refs #41515

### DIFF
--- a/war/src/main/webapp/themes/default/css/aui.css
+++ b/war/src/main/webapp/themes/default/css/aui.css
@@ -5662,6 +5662,12 @@ a.auiIconMailOpen:hover {
   text-decoration: none;
   text-shadow: none;
 }
+#messageRoomSetting .auiWFicon,
+#messageRoomSetting .auiWFicon [class^="icon-"] {
+  height: 24px;
+  width: 24px;
+  line-height: 24px;
+}
 
 a:hover .auiWFicon [class^="icon-"] {
   color: #333333;


### PR DESCRIPTION
メッセージ > ルーム設定と通知設定の歯車アイコンの位置調整
CSS文字化けしていたので、ブランチ切り直しました。