### PR TITLE
スケジュール > スケジュール詳細の印刷画面のパラメータの日付に閉じ括弧が渡されている

### DIFF
--- a/portlets/schedule/src/main/webapp/WEB-INF/templates/vm/portlets/html/ajax-schedule-detail.vm
+++ b/portlets/schedule/src/main/webapp/WEB-INF/templates/vm/portlets/html/ajax-schedule-detail.vm
@@ -22,7 +22,7 @@
 #set ($indicator_id = "indicator-dlg-")
 ## ---------------------------------------------------------------------------
 #if (${client}!= "IPHONE")
-	#ALdialogheaderPrintSchedule($l10n.SCHEDULE_SCHEDULE_DETAIL "$!portlet.ID" "ScheduleDetailScreenPrint" "$!{result.getViewDate().toString()})" "$!{result.Detail.User.UserId.toString()}" "$entityid")
+	#ALdialogheaderPrintSchedule($l10n.SCHEDULE_SCHEDULE_DETAIL "$!portlet.ID" "ScheduleDetailScreenPrint" "$!{result.getViewDate().toString()}" "$!{result.Detail.User.UserId.toString()}" "$entityid")
 #else
 	#ALdialogheaderDetailSmartPhone("$l10n.SCHEDULE_SCHEDULE_DETAIL")
 #end


### PR DESCRIPTION
修正箇所:ajax-schedule-detail.vmの25行目、マクロに渡す引数の4つ目view_dateに")"が余計に記述されていたため、削除した